### PR TITLE
startup setting "Include poles without wires"

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -72,7 +72,7 @@ for _, item in pairs (data.raw["item"]) do
   if item.place_result and data.raw["electric-pole"][item.place_result] and not pole_entity_blacklist[item.place_result] then
     -- log("[LEP+] found pole "..item.place_result.." in item "..item.name)
     local pole = data.raw["electric-pole"][item.place_result]
-    if pole.draw_copper_wires ~= false -- exclude poles without copper wire connection
+    if (pole.draw_copper_wires ~= false or settings.startup["lepp_include_wireless_pole"].value == true) -- exclude poles without copper wire connection
     and pole.maximum_wire_distance and pole.maximum_wire_distance > 0 -- exclude poles with no wire reach
     and pole.minable and pole.minable.result and pole.minable.result == item.name then
 

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -11,6 +11,10 @@ local flib = require('__flib__.data-util')
 local light_scale = settings.startup["lepp_light_size_factor"].value
 local light_size_limit = settings.startup["lepp_light_max_size"].value
 local lep_icons_layer = { { icon = "__LightedPolesPlus__/graphics/icons/lighted.png", icon_size = 32, tint = {r=1, g=1, b=1, a=0.85} } }
+local pole_entity_whitelist = {}
+for name in gmatch(settings.startup["lepp_pole_whitelist"].value, '([^, *]+)') do
+  pole_entity_whitelist[name] = true
+end
 local pole_entity_blacklist = {}
 for name in gmatch(settings.startup["lepp_pole_blacklist"].value, '([^, *]+)') do
   pole_entity_blacklist[name] = true
@@ -72,9 +76,10 @@ for _, item in pairs (data.raw["item"]) do
   if item.place_result and data.raw["electric-pole"][item.place_result] and not pole_entity_blacklist[item.place_result] then
     -- log("[LEP+] found pole "..item.place_result.." in item "..item.name)
     local pole = data.raw["electric-pole"][item.place_result]
-    if (pole.draw_copper_wires ~= false or settings.startup["lepp_include_wireless_pole"].value == true) -- exclude poles without copper wire connection
+    if pole_entity_whitelist[item.place_result] -- include if whitelisted
+    or (pole.draw_copper_wires ~= false -- exclude poles without copper wire connection
     and pole.maximum_wire_distance and pole.maximum_wire_distance > 0 -- exclude poles with no wire reach
-    and pole.minable and pole.minable.result and pole.minable.result == item.name then
+    and pole.minable and pole.minable.result and pole.minable.result == item.name) then
 
       pole.fast_replaceable_group = pole.fast_replaceable_group or "electric-pole"
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -7,7 +7,7 @@ lighted-pole=Lighted __1__
 [mod-setting-name]
 lepp_light_size_factor=Light radius scale
 lepp_light_max_size=Maximum light size
-lepp_include_wireless_pole=Poles without wires
+lepp_pole_whitelist=Pole Whitelist
 lepp_pole_blacklist=Pole Blacklist
 lepp_tech_blacklist=Technology Blacklist
 lepp_tech_fallback=Fallback Technology
@@ -15,7 +15,7 @@ lepp_tech_fallback=Fallback Technology
 [mod-setting-description]
 lepp_light_size_factor=Factor applied on top of scaling with wire distance.\nSet to 0 to use the equivalent of a small lamp on every pole.
 lepp_light_max_size=Values > 75 may produce graphical issues.
-lepp_include_wireless_pole=Include poles which do not display wires.
+lepp_pole_whitelist=Comma separated list if pole entities LEP+ should create lighted version of.
 lepp_pole_blacklist=Comma separated list of pole entities LEP+ shouldn't create lighted versions of.
 lepp_tech_blacklist=Comma separated list of technologies LEP+ shouldn't add recipe unlocks to.
 lepp_tech_fallback=Technology used for lighted pole recipe unlocks for base poles without technology unlocks like Small electric pole.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -7,6 +7,7 @@ lighted-pole=Lighted __1__
 [mod-setting-name]
 lepp_light_size_factor=Light radius scale
 lepp_light_max_size=Maximum light size
+lepp_include_wireless_pole=Poles without wires
 lepp_pole_blacklist=Pole Blacklist
 lepp_tech_blacklist=Technology Blacklist
 lepp_tech_fallback=Fallback Technology
@@ -14,6 +15,7 @@ lepp_tech_fallback=Fallback Technology
 [mod-setting-description]
 lepp_light_size_factor=Factor applied on top of scaling with wire distance.\nSet to 0 to use the equivalent of a small lamp on every pole.
 lepp_light_max_size=Values > 75 may produce graphical issues.
+lepp_include_wireless_pole=Include poles which do not display wires.
 lepp_pole_blacklist=Comma separated list of pole entities LEP+ shouldn't create lighted versions of.
 lepp_tech_blacklist=Comma separated list of technologies LEP+ shouldn't add recipe unlocks to.
 lepp_tech_fallback=Technology used for lighted pole recipe unlocks for base poles without technology unlocks like Small electric pole.

--- a/settings.lua
+++ b/settings.lua
@@ -17,11 +17,11 @@ data:extend({
     minimum_value = 1,
   },
   {
-    type = "bool-setting",
-    name = "lepp_include_wireless_pole",
+    type = "string-setting",
+    name = "lepp_pole_whitelist",
     order = "ba",
     setting_type = "startup",
-    default_value = "false",
+    default_value = "fish-pole,slp-dec-med-pole,slp-dec-big-pole,slp-dec-sub-pole",
   },
   {
     type = "string-setting",

--- a/settings.lua
+++ b/settings.lua
@@ -21,6 +21,7 @@ data:extend({
     name = "lepp_pole_whitelist",
     order = "ba",
     setting_type = "startup",
+    allow_blank = true,
     default_value = "fish-pole,slp-dec-med-pole,slp-dec-big-pole,slp-dec-sub-pole",
   },
   {

--- a/settings.lua
+++ b/settings.lua
@@ -26,7 +26,7 @@ data:extend({
   {
     type = "string-setting",
     name = "lepp_pole_blacklist",
-    order = "ba",
+    order = "bb",
     setting_type = "startup",
     allow_blank = true,
     default_value = "bi-power-to-rail-pole,bi-rail-hidden-power-pole,ee-super-electric-pole,ee-super-substation",
@@ -34,7 +34,7 @@ data:extend({
   {
     type = "string-setting",
     name = "lepp_tech_blacklist",
-    order = "bb",
+    order = "bc",
     setting_type = "startup",
     allow_blank = true,
     default_value = "",
@@ -42,11 +42,9 @@ data:extend({
   {
     type = "string-setting",
     name = "lepp_tech_fallback",
-    order = "bc",
+    order = "bd",
     setting_type = "startup",
     allow_blank = false,
     default_value = "optics",
   },
 })
-
-

--- a/settings.lua
+++ b/settings.lua
@@ -17,6 +17,13 @@ data:extend({
     minimum_value = 1,
   },
   {
+    type = "bool-setting",
+    name = "lepp_include_wireless_pole",
+    order = "ba",
+    setting_type = "startup",
+    default_value = "false",
+  },
+  {
     type = "string-setting",
     name = "lepp_pole_blacklist",
     order = "ba",


### PR DESCRIPTION
Add a startup option to include poles which do not display copper wire connections.